### PR TITLE
i18n（作品投稿画面）

### DIFF
--- a/front/messages/en.json
+++ b/front/messages/en.json
@@ -51,8 +51,8 @@
   "Sidebar": {
     "home": "Home",
     "create_mask": "Create Gamut Mask",
-    "work_list": "Works",
-    "post_work": "Post Work",
+    "artwork_gallery": "Artwork Gallery",
+    "artwork": "Artwork",
     "settings": "Settings",
     "menu": "Menu",
     "others": "Others"
@@ -145,9 +145,9 @@
     "ok": "OK",
     "cancel": "Cancel"
   },
-  "Works": {
+  "Artworks": {
     "popular_tags": "Popular Tags",
-    "work": "work"
+    "artwork": "Artwork"
   },
   "Search": {
     "placeholder": "Search"
@@ -157,6 +157,27 @@
     "popularity_order": "MOST POPULAR",
     "oldest_order": "OLDEST",
     "newest_order": "NEWEST"
+  },
+  "PostWork": {
+    "failed_to_post": "Failed to post",
+    "artwork": "Artwork",
+    "illustration_artwork": "Illustration Artwork",
+    "selected": "Selected",
+    "required": "Required",
+    "title": "Artwork Title",
+    "title_placeholder": "Up to 30 characters",
+    "description": "Artwork Description",
+    "description_placeholder": "Up to 300 characters",
+    "mask_used_in_the_artwork": "Mask used in the artwork",
+    "tags": "tags",
+    "save_as_draft": "Save as draft",
+    "post": "Post"
+  },
+  "Tags": {
+    "title": "Tags",
+    "placeholder": "Please enter a tag and press the Enter key or the Add button.",
+    "add_button": "add",
+    "help": "You can add tags by pressing the Enter key or the Add button. You can remove tags by clicking them."
   },
   "Header": {
     "login": "Login",

--- a/front/messages/ja.json
+++ b/front/messages/ja.json
@@ -51,8 +51,8 @@
   "Sidebar": {
     "home": "ホーム",
     "create_mask": "ガマットマスク作成",
-    "work_list": "作品一覧",
-    "post_work": "作品投稿",
+    "artwork_gallery": "作品一覧",
+    "artwork": "作品投稿",
     "settings": "設定",
     "menu": "メニュー",
     "others": "その他"
@@ -145,9 +145,9 @@
     "ok": "はい",
     "cancel": "キャンセル"
   },
-  "Works": {
+  "Artworks": {
     "popular_tags": "人気タグ",
-    "work": "作品"
+    "artwork": "作品"
   },
   "Search": {
     "placeholder": "検索"
@@ -157,6 +157,27 @@
     "popularity_order": "人気順",
     "oldest_order": "古い順",
     "newest_order": "新しい順"
+  },
+  "PostWork": {
+    "failed_to_post": "投稿に失敗しました",
+    "artwork": "作品投稿",
+    "illustration_artwork": "イラスト作品",
+    "selected": "選択中",
+    "required": "必須",
+    "title": "作品タイトル",
+    "title_placeholder": "最大30文字まで",
+    "description": "作品説明文",
+    "description_placeholder": "最大300文字まで",
+    "mask_used_in_the_artwork": "作品で使用したマスク",
+    "tags": "タグ",
+    "save_as_draft": "下書き保存",
+    "post": "投稿"
+  },
+  "Tags": {
+    "title": "タグ",
+    "placeholder": "タグを入力してEnterキーまたは追加ボタンを押してください",
+    "add_button": "追加",
+    "help": "Enterキーまたは追加ボタンでタグを追加できます。タグをクリックして削除できます。"
   },
   "Header": {
     "login": "ログイン",

--- a/front/src/app/[locale]/work/new/page.tsx
+++ b/front/src/app/[locale]/work/new/page.tsx
@@ -19,6 +19,7 @@ import { AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useAuthRedirect } from "@/hooks/useAuthRedirect";
 import { useLoad } from "@/contexts/LoadingContext";
 import { useAuth } from "@/contexts/AuthContext";
+import { useTranslations } from "next-intl";
 
 // 型定義(公開設定)
 type PublicStatus = 0 | 1 | 2; // published: 0, restricted: 1, draft: 2
@@ -39,6 +40,7 @@ export default function PostWorks() {
   const [isPresetDialogOpen, setIsPresetDialogOpen] = useState(false);
   const [illustrationFile, setIllustrationFile] = useState<File | null>(null);
   const [illustrationPreview, setIllustrationPreview] = useState<string | null>(null);
+  const t = useTranslations('PostWork');
 
   useEffect(() => {
     if (!illustrationFile){
@@ -130,7 +132,7 @@ export default function PostWorks() {
         {errors.length > 0 && (
           <Alert className="bg-card text-error mb-6">
             <AlertCircleIcon className="h-4 w-4" />
-            <AlertTitle className="font-semibold">投稿に失敗しました</AlertTitle>
+            <AlertTitle className="font-semibold">{t('failed_to_post')}</AlertTitle>
             <AlertDescription>
               <ul className="text-error font-semibold space-y-1 mt-2">
                 {errors.map((error, index) => (
@@ -142,7 +144,7 @@ export default function PostWorks() {
         )}
         <div className="flex justify-between mb-16">
           <div className="flex items-center">
-            <h1 className="text-label text-4xl font-extrabold">作品投稿</h1>
+            <h1 className="text-label text-4xl font-extrabold">{t('artwork')}</h1>
           </div>
           <div className="flex items-center gap-x-2">
           </div>
@@ -152,8 +154,8 @@ export default function PostWorks() {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16">
               <div>
                 <Label className="text-label font-semibold mb-2">
-                  イラスト作品
-                  <Label className="bg-destructive p-1 rounded-xs">必須</Label>
+                  {t('illustration_artwork')}
+                  <Label className="bg-destructive p-1 rounded-xs">{t('required')}</Label>
                 </Label>
                 <DropZone
                   onFileSelect={setIllustrationFile}
@@ -162,20 +164,20 @@ export default function PostWorks() {
                 />
                 {illustrationFile && (
                     (illustrationFile.size / 1024 / 1024) < 1 ? (
-                    <span className="flex justify-end text-sm text-gray-600 mt-2">
-                      選択中: {illustrationFile.name} ({Math.round(illustrationFile.size / 1024)}KB)
+                    <span className="flex justify-end text-sm text-gray-600 mt-2 line-clamp-1">
+                      {t('selected')}: {illustrationFile.name} ({Math.round(illustrationFile.size / 1024)}KB)
                     </span>
                     ) : (
-                    <span className="flex justify-end text-sm text-gray-600 mt-2">
-                      選択中: {illustrationFile.name} ({(illustrationFile.size / 1024 / 1024).toFixed(2)}MB)
+                    <span className="flex justify-end text-sm text-gray-600 mt-2 line-clamp-1">
+                      {t('selected')}: {illustrationFile.name} ({(illustrationFile.size / 1024 / 1024).toFixed(2)}MB)
                     </span>
                     )
                 )}
               </div>
               <div className="gap-2">
                 <Label className="text-label font-semibold mb-2">
-                  作品で使用したマスク
-                  <Label className="bg-destructive p-1 rounded-xs">必須</Label>
+                  {t('mask_used_in_the_artwork')}
+                  <Label className="bg-destructive p-1 rounded-xs">{t('required')}</Label>
                 </Label>
                 <div
                   className="cursor-pointer"
@@ -192,8 +194,8 @@ export default function PostWorks() {
                       >
                         <X className="w-4 h-4 text-white" />
                       </button>
-                      <span className="flex justify-end text-sm text-gray-600 mt-2">
-                        選択中: {presetData.name}
+                      <span className="flex justify-end text-sm text-gray-600 mt-2 line-clamp-1">
+                        {t('selected')}: {presetData.name}
                       </span>
                     </div>
                   ) : (
@@ -220,23 +222,23 @@ export default function PostWorks() {
             <div className="grid grid-cols gap-6">
               <div>
                 <Label className="text-label font-semibold mb-2">
-                  作品タイトル
-                  <Label className="bg-destructive p-1 rounded-xs">必須</Label>
+                  {t('title')}
+                  <Label className="bg-destructive p-1 rounded-xs">{t('required')}</Label>
                 </Label>
                 <Input
                   value={formData.title}
                   onChange={(e)=> handleInputChange('title', e.target.value)}
-                  placeholder="最大30文字まで"
+                  placeholder={t('title_placeholder')}
                   required
                 />
               </div>
               <div>
-                <Label className="text-label font-semibold mb-2">作品説明</Label>
+                <Label className="text-label font-semibold mb-2">{t('description')}</Label>
                 <Textarea
                   className="h-32"
                   value={formData.description}
                   onChange={(e)=> handleInputChange('description', e.target.value)}
-                  placeholder="最大300文字まで"
+                  placeholder={t('description_placeholder')}
                 />
               </div>
               <div>
@@ -255,13 +257,13 @@ export default function PostWorks() {
                 variant="secondary"
                 onClick={(e) => handleSubmit(e, true)}  // true(下書き)を渡す
               >
-                下書き保存
+                {t('save_as_draft')}
               </Button>
               <Button
                 type="button"
                 onClick={(e) => handleSubmit(e, false)} // false(公開)を渡す
               >
-                投稿
+                {t('post')}
               </Button>
             </div>
         </form>

--- a/front/src/app/[locale]/work/page.tsx
+++ b/front/src/app/[locale]/work/page.tsx
@@ -31,7 +31,7 @@ function WorksListContent() {
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(''); // searchQueryの値を保存（デバウンス処理用）
   const [isInitialized, setIsInitialized] = useState(false);
 
-  const t = useTranslations('Works');
+  const t = useTranslations('Artworks');
   const locale = useLocale();
 
   // URLパラメータから初期検索クエリとタグを取得し、同時に作品を取得

--- a/front/src/components/TagInput.tsx
+++ b/front/src/components/TagInput.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { X } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
 
 interface TagInputProps {
   tags: string[];
@@ -23,6 +24,8 @@ export function TagInput({
   const [inputValue, setInputValue] = useState('');
   const [error, setError] = useState('');
   const [isComposing, setIsComposing] = useState(false); // IME変換中フラグ
+  const t = useTranslations('Tags');
+  const locale = useLocale();
 
   const addTag = (tagName: string) => {
     const trimmedTag = tagName.trim();
@@ -83,10 +86,16 @@ export function TagInput({
   return (
     <div className="space-y-3">
       <Label className="text-label font-semibold">
-        タグ
-        <span className="text-xs text-gray-500 ml-2">
-          (最大{maxTags}個、各{maxTagLength}文字以内)
-        </span>
+        {t('title')}
+        {locale === 'ja' ? (
+          <span className="text-xs text-gray-500 ml-2">
+            (最大{maxTags}個、各{maxTagLength}文字以内)
+          </span>
+        ) : (
+          <span className="text-xs text-gray-500 ml-2">
+            ( Up to {maxTags} keywords, {maxTagLength} characters maximum each. )
+          </span>
+          )}
       </Label>
 
       {/* タグ表示エリア */}
@@ -123,7 +132,7 @@ export function TagInput({
           onKeyDown={handleKeyDown}
           onCompositionStart={handleCompositionStart} // IME変換開始
           onCompositionEnd={handleCompositionEnd}     // IME変換終了
-          placeholder="タグを入力してEnterキーまたは追加ボタンを押してください"
+          placeholder={t('placeholder')}
           maxLength={maxTagLength}
           disabled={tags.length >= maxTags}
         />
@@ -134,7 +143,7 @@ export function TagInput({
           variant="secondary"
           className="whitespace-nowrap"
         >
-          追加
+          {t('add_button')}
         </Button>
       </div>
 
@@ -145,7 +154,7 @@ export function TagInput({
 
       {/* ヘルプテキスト */}
       <p className="text-xs text-gray-500">
-        Enterキーまたは追加ボタンでタグを追加できます。タグをクリックして削除できます。
+        {t('help')}
       </p>
     </div>
   );

--- a/front/src/components/app-sidebar.tsx
+++ b/front/src/components/app-sidebar.tsx
@@ -54,12 +54,12 @@ export function AppSidebar() {
       icon: Palette,
     },
     {
-      title: t('work_list'),
+      title: t('artwork_gallery'),
       url: "/work",
       icon: ImageIcon,
     },
     {
-      title: t('post_work'),
+      title: t('artwork'),
       url: "/work/new",
       icon: PenTool,
     },

--- a/front/src/components/ui/dropzone.tsx
+++ b/front/src/components/ui/dropzone.tsx
@@ -1,3 +1,4 @@
+import { useLocale } from "next-intl";
 import { Input } from "./input";
 import { User, X } from 'lucide-react';
 
@@ -9,6 +10,9 @@ type DropZoneProps = {
 };
 
 export function DropZone({ onFileSelect, accept, isAvatarImage, previewUrl }: DropZoneProps){
+
+  const locale = useLocale();
+
   // ドラッグ&ドロップ対応
   const handleDrop = (e: React.DragEvent<HTMLLabelElement>) => {
     e.preventDefault();
@@ -116,7 +120,11 @@ export function DropZone({ onFileSelect, accept, isAvatarImage, previewUrl }: Dr
                 <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 13h3a3 3 0 0 0 0-6h-.025A5.56 5.56 0 0 0 16 6.5 5.5 5.5 0 0 0 5.207 5.021C5.137 5.017 5.071 5 5 5a4 4 0 0 0 0 8h2.167M10 15V6m0 0L8 8m2-2 2 2"/>
               </svg>
               <p className="mb-2 text-sm text-gray-500"><span className="font-semibold">Click to upload</span> or drag and drop</p>
-              <p className="text-xs text-gray-500">PNG, JPG or JPEG（最大16MBまで）</p>
+              {locale === 'ja' ? (
+                <p className="text-xs text-gray-500">PNG, JPG or JPEG（最大16MBまで）</p>
+              ) : (
+                <p className="text-xs text-gray-500">PNG, JPG or JPEG（Up to 16MB）</p>
+              )}
             </div>
           )}
           <Input


### PR DESCRIPTION
作品投稿画面（/work/new）の[i18n対応](https://github.com/Yu-RGB555/GamutCut/issues/280)を実施

以下の項目も追加で対応
- サイドバーメニュー項目
1. 「Work List」を「Artwork Gallery」へ
2. 「Post Work」を「Artwork」へ