### PR TITLE
i18n対応（作品詳細画面）

### DIFF
--- a/front/messages/en.json
+++ b/front/messages/en.json
@@ -195,6 +195,23 @@
     "terms_of_service": "Terms of Service",
     "contact": "Contact"
   },
+  "WorkDetail": {
+    "work_not_found": "Work not found...",
+    "edit": "Edit",
+    "delete": "Delete",
+    "delete_confirmation_title": "Confirm Deletion",
+    "delete_confirmation_message": "Once deleted, it cannot be recovered.",
+    "delete_confirmation_question": "Are you sure you want to delete?",
+    "cancel": "Cancel",
+    "yes": "Yes",
+    "no_image": "No image",
+    "mask_used_in_work": "Mask used in this work",
+    "copy_and_edit": "Copy and Edit",
+    "mask_not_set": "Mask not set",
+    "tags": "Tags",
+    "delete_failed": "Failed to delete work",
+    "mask_copied": "Mask copied. Redirecting to mask creation page."
+  },
   "TermsOfService": {
     "title": "Terms of Service",
     "intro": "These Terms of Service (hereinafter referred to as \"these Terms\") set forth the terms and conditions for using the service (hereinafter referred to as \"the Service\") provided by {serviceName} (hereinafter referred to as \"the Company\") on this website. All registered users (hereinafter referred to as \"Users\") shall use the Service in accordance with these Terms.",

--- a/front/messages/ja.json
+++ b/front/messages/ja.json
@@ -319,6 +319,23 @@
     },
     "end": "以上"
   },
+  "WorkDetail": {
+    "work_not_found": "作品が見つかりません...",
+    "edit": "編集",
+    "delete": "削除",
+    "delete_confirmation_title": "作品削除の確認",
+    "delete_confirmation_message": "一度削除すると元に戻すことができなくなります。",
+    "delete_confirmation_question": "本当に削除しますか？",
+    "cancel": "キャンセル",
+    "yes": "はい",
+    "no_image": "画像なし",
+    "mask_used_in_work": "作品で使用したマスク",
+    "copy_and_edit": "コピーして編集",
+    "mask_not_set": "マスク未設定",
+    "tags": "タグ",
+    "delete_failed": "作品の削除に失敗しました",
+    "mask_copied": "マスクをコピーしました。マスク作成画面に移ります。"
+  },
   "PrivacyPolicy": {
     "title": "プライバシーポリシー",
     "intro": "{serviceName}（以下、「当社」といいます。）は、本ウェブサイト上で提供するサービス（以下、「本サービス」といいます。）における、ユーザーの個人情報の取扱いについて、以下のとおりプライバシーポリシー（以下、「本ポリシー」といいます。）を定めます。",

--- a/front/src/app/[locale]/work/[id]/work-detail-client.tsx
+++ b/front/src/app/[locale]/work/[id]/work-detail-client.tsx
@@ -3,6 +3,7 @@
 
 import { useState } from "react";
 import { useRouter } from '@/i18n/routing';
+import { useTranslations } from 'next-intl';
 import { useParams } from "next/navigation";
 import { Link } from '@/i18n/routing';
 import { Button } from "@/components/ui/button";
@@ -41,6 +42,7 @@ export function WorkDetailClient({initialData}: WorkDetailClientProps) {
   const id = params?.id;
   const { user } = useAuth();
   const { showAlert } = useAlert();
+  const t = useTranslations('WorkDetail');
   const { setIsLoadingOverlay } = useLoad();
   const [work, setWork] = useState(initialData);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -66,7 +68,7 @@ export function WorkDetailClient({initialData}: WorkDetailClientProps) {
       }
     } catch (error) {
       console.error(error);
-      showAlert('作品の削除に失敗しました');
+      showAlert(t('delete_failed'));
     } finally {
       setIsLoadingOverlay(false);
     }
@@ -76,7 +78,7 @@ export function WorkDetailClient({initialData}: WorkDetailClientProps) {
   const handleCopyMask = (maskData: MaskData) => {
     // マスクデータをlocalStorageに保存
     localStorage.setItem('copiedMaskData', JSON.stringify(maskData));
-    showAlert('マスクをコピーしました。マスク作成画面に移ります。');
+    showAlert(t('mask_copied'));
     // 少し遅延を入れてからページ遷移
     setTimeout(() => {
       router.push('/mask');
@@ -86,7 +88,7 @@ export function WorkDetailClient({initialData}: WorkDetailClientProps) {
   if (!work) {
     return <div className="flex min-h-[500px] justify-center items-center">
       <div className="text-white text-center font-semibold">
-        作品が見つかりません...
+        {t('work_not_found')}
       </div>
     </div>;
   }
@@ -95,7 +97,7 @@ export function WorkDetailClient({initialData}: WorkDetailClientProps) {
   if ( work.is_public !== "published" && user?.id !== work.user.id) {
     return <div className="flex min-h-[500px] justify-center items-center">
       <div className="text-white text-center font-semibold">
-        作品が見つかりません...
+        {t('work_not_found')}
       </div>
     </div>;
   }
@@ -116,11 +118,11 @@ export function WorkDetailClient({initialData}: WorkDetailClientProps) {
             <Button
               variant="secondary"
               onClick={() => handleEdit(work.id)}
-            >編集</Button>
+            >{t('edit')}</Button>
             <Button
               variant="destructive"
               onClick={() => setIsDialogOpen(true)}
-            >削除</Button>
+            >{t('delete')}</Button>
           </div>
         )}
       </div>
@@ -129,18 +131,18 @@ export function WorkDetailClient({initialData}: WorkDetailClientProps) {
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <DialogTitle>作品削除の確認</DialogTitle>
-            <DialogDescription className="text-label pt-2">一度削除すると元に戻すことができなくなります。<br />本当に削除しますか？</DialogDescription>
+            <DialogTitle>{t('delete_confirmation_title')}</DialogTitle>
+            <DialogDescription className="text-label pt-2">{t('delete_confirmation_message')}<br />{t('delete_confirmation_question')}</DialogDescription>
           </DialogHeader>
           <DialogFooter>
             <Button
               variant="secondary"
               onClick={() => setIsDialogOpen(false)}
-            >キャンセル</Button>
+            >{t('cancel')}</Button>
             <Button
               variant="secondary"
               onClick={() => handleDelete(work.id)}
-            >はい</Button>
+            >{t('yes')}</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -158,14 +160,14 @@ export function WorkDetailClient({initialData}: WorkDetailClientProps) {
                   className="object-cover w-full h-full"
                 />
               ) : (
-                <span className="text-gray-500">画像なし</span>
+                <span className="text-gray-500">{t('no_image')}</span>
               )}
             </div>
           </div>
 
           {/* 作品で使用したマスク */}
           <div className="flex flex-1 flex-col">
-            <Label className="text-label font-semibold mb-2">作品で使用したマスク</Label>
+            <Label className="text-label font-semibold mb-2">{t('mask_used_in_work')}</Label>
               <div>
                 {work.set_mask_data ? (
                   <div className="grid grid-row-2 relative">
@@ -175,13 +177,13 @@ export function WorkDetailClient({initialData}: WorkDetailClientProps) {
                       className="mt-2"
                       onClick={() => handleCopyMask(work.set_mask_data)}
                     >
-                      コピーして編集
+                      {t('copy_and_edit')}
                     </Button>
                   </div>
                 ) : (
                   <div className="justify-center w-full h-full border rounded-lg cursor-pointer">
                     <div className="flex flex-col items-center justify-center h-80">
-                      <p className="mb-2 text-sm font-semibold text-gray-500">マスク未設定</p>
+                      <p className="mb-2 text-sm font-semibold text-gray-500">{t('mask_not_set')}</p>
                       <p className="text-xs text-gray-500"></p>
                     </div>
                   </div>
@@ -237,7 +239,7 @@ export function WorkDetailClient({initialData}: WorkDetailClientProps) {
           {/* タグ表示エリア */}
           {work.tags && work.tags.length > 0 && (
             <div className="mt-4">
-              <Label className="text-label font-semibold mb-3 block">タグ</Label>
+              <Label className="text-label font-semibold mb-3 block">{t('tags')}</Label>
               <div className="flex flex-wrap gap-2">
                 {work.tags.map((tag) => (
                   <Link


### PR DESCRIPTION
作品詳細画面（/work/[id]）の[i18n対応](https://github.com/Yu-RGB555/GamutCut/issues/280)を実施