### PR TITLE
localStorageに保存するリダイレクトURLの修正

### DIFF
--- a/front/src/components/CommentForm.tsx
+++ b/front/src/components/CommentForm.tsx
@@ -66,7 +66,8 @@ export function CommentForm({ workId, onCommentCreated }: CommentFormProps) {
           size="sm"
           onClick={() => {
             // localStorageにパスを保存してログイン画面へ遷移
-            localStorage.setItem('redirectAfterLogin', window.location.pathname);
+            const redirectPath = window.location.pathname.replace(/^\/(en|ja)/, '')
+            localStorage.setItem('redirectAfterLogin', redirectPath);
             router.push('/auth/login');
           }}
         >


### PR DESCRIPTION
作品詳細画面にあるコメント領域のログインボタンを押下して、ログイン画面へ遷移後、ログイン or SNS認証ログインすると、localStorageに保存不要な「en/」も含めて保存してしまい、「/en/en/」を生成してしまっていた（※jaも然り）。
そのため、localStorageにセットする際、replaceメソッドでlocale部分を除去することで解消。

・対象ISSUE
[認証ログイン後に「en/en/」となる件](https://github.com/Yu-RGB555/GamutCut/issues/321)