### PR TITLE
【追加】色相環の回転機能

### DIFF
--- a/front/messages/en.json
+++ b/front/messages/en.json
@@ -71,6 +71,7 @@
     "alert_max_masks": "You can add up to 3 masks.",
     "alert_save_fail": "Failed to save mask",
     "value": "Value",
+    "rotation": "Rotation",
     "my_mask_list": "My Mask List",
     "color_info": "Color Info",
     "hue": "Hue",

--- a/front/messages/ja.json
+++ b/front/messages/ja.json
@@ -71,6 +71,7 @@
     "alert_max_masks": "マスクの追加は最大3つまでです",
     "alert_save_fail": "マスクの保存に失敗しました",
     "value": "明度",
+    "rotation": "回転",
     "my_mask_list": "Myマスク一覧",
     "color_info": "色情報",
     "hue": "色相",

--- a/front/src/components/MaskMaking.tsx
+++ b/front/src/components/MaskMaking.tsx
@@ -51,6 +51,7 @@ export function MaskMaking({ onSaveSuccess, copiedMaskData }: MaskMakingProps) {
 
   // 色相環パラメータ
   const [currentValue, setCurrentValue] = useState<number>(100);
+  const [rotation, setRotation] = useState<number>(0);
   const [colorInfo, setColorInfo] = useState<ColorInfo>({
     coordinates: '-',
     hue: '-',
@@ -89,7 +90,7 @@ export function MaskMaking({ onSaveSuccess, copiedMaskData }: MaskMakingProps) {
     if (!ctx) return;
 
     // 色相環を描画
-    colorWheelDrawer.draw(ctx, canvas.width, canvas.height, currentValue);
+    colorWheelDrawer.draw(ctx, canvas.width, canvas.height, currentValue, rotation);
 
     if (selectedMask.length === 0) {
       return; // マスクがない場合はグレーアウト処理をしない
@@ -161,7 +162,7 @@ export function MaskMaking({ onSaveSuccess, copiedMaskData }: MaskMakingProps) {
     const centerX = canvas.width / 2;
     const centerY = canvas.height / 2;
 
-    const { hue, saturation, distance } = getColorFromCoords(x, y, centerX, centerY, colorWheelDrawer.getMaxRadius());
+    const { hue, saturation, distance } = getColorFromCoords(x, y, centerX, centerY, colorWheelDrawer.getMaxRadius(), rotation);
 
     // 色情報の取得
     if (distance <= colorWheelDrawer.getMaxRadius()) {
@@ -373,6 +374,7 @@ export function MaskMaking({ onSaveSuccess, copiedMaskData }: MaskMakingProps) {
         name: presetName,
         mask_data: {
           value: currentValue,
+          rotation: rotation,
           masks: currentMasks,
         }
       };
@@ -440,6 +442,7 @@ export function MaskMaking({ onSaveSuccess, copiedMaskData }: MaskMakingProps) {
 
       setSelectedMask(restoredMasks);
       setCurrentValue(copiedMaskData.value);
+      setRotation(copiedMaskData.rotation ?? 0);
       setSelectedMaskIndex(restoredMasks.length > 0 ? restoredMasks.length - 1 : 0);
     }
   }, [copiedMaskData]);
@@ -448,7 +451,7 @@ export function MaskMaking({ onSaveSuccess, copiedMaskData }: MaskMakingProps) {
   useEffect(() => {
     redraw();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentValue, selectedMask]);
+  }, [currentValue, rotation, selectedMask]);
 
   return (
     <>
@@ -486,6 +489,23 @@ export function MaskMaking({ onSaveSuccess, copiedMaskData }: MaskMakingProps) {
                     className="w-1/2 h-2 hover:cursor-pointer"
                   />
                   <span className="text-label">{currentValue}%</span>
+                </div>
+              </div>
+
+              {/* 回転調整スライダー */}
+              <div className="w-full space-y-2">
+                <h3 className="text-card-foreground text-lg font-semibold">{t('rotation')}</h3>
+                <div className="flex items-center sm:flex-row gap-2 sm:gap-4">
+                  <Slider
+                    defaultValue={[0]}
+                    value={[rotation]}
+                    min={0}
+                    max={360}
+                    step={1}
+                    onValueChange={(value) => setRotation(value[0])}
+                    className="w-1/2 h-2 hover:cursor-pointer"
+                  />
+                  <span className="text-label">{rotation}°</span>
                 </div>
               </div>
 

--- a/front/src/components/PresetCard.tsx
+++ b/front/src/components/PresetCard.tsx
@@ -81,7 +81,7 @@ export function PresetCard({ preset, onDeleteSuccess, showEditButton = true, sho
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
     // 色相環を描画
-    colorWheelDrawer.draw(ctx, CARD_CANVAS_SIZE, CARD_CANVAS_SIZE, preset.mask_data.value);
+    colorWheelDrawer.draw(ctx, CARD_CANVAS_SIZE, CARD_CANVAS_SIZE, preset.mask_data.value, preset.mask_data.rotation ?? 0);
 
     // マスクを描画
     if (preset.mask_data.masks.length > 0) {

--- a/front/src/components/PresetPreview.tsx
+++ b/front/src/components/PresetPreview.tsx
@@ -52,7 +52,7 @@ export function PresetPreview({ maskData, size =300 }: PresetPreviewProps) {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
     // 色相環を描画
-    colorWheelDrawer.draw(ctx, PREVIEW_CANVAS_SIZE, PREVIEW_CANVAS_SIZE, maskData.value);
+    colorWheelDrawer.draw(ctx, PREVIEW_CANVAS_SIZE, PREVIEW_CANVAS_SIZE, maskData.value, maskData.rotation ?? 0);
 
     // マスクを描画
     if (maskData.masks.length > 0) {

--- a/front/src/lib/colorUtils.ts
+++ b/front/src/lib/colorUtils.ts
@@ -37,13 +37,13 @@ export const hsvToRgb = (h: number, s: number, v: number): [number, number, numb
 };
 
 // 各座標(x, y)の色相と彩度を定義
-export const getColorFromCoords = (x: number, y: number, centerX: number, centerY: number, maxRadius: number) => {
+export const getColorFromCoords = (x: number, y: number, centerX: number, centerY: number, maxRadius: number, rotation: number = 0) => {
   const dx = x - centerX;
   const dy = y - centerY;
   const distance = Math.sqrt(dx * dx + dy * dy);
   const angle = Math.atan2(dy, dx) * 180 / Math.PI;
 
-  const hue = (angle + 90 + 360) % 360;
+  const hue = ((angle + 90 - rotation) % 360 + 360) % 360;
   const saturation = Math.max(0, Math.min(100, (distance / maxRadius) * 100));
 
   return { hue, saturation, distance };

--- a/front/src/lib/colorWheelDrawer.ts
+++ b/front/src/lib/colorWheelDrawer.ts
@@ -9,7 +9,7 @@ export class ColorWheelDrawer {
     this.sectorCount = sectorCount;
   }
 
-  draw(ctx: CanvasRenderingContext2D, width: number, height: number, value: number) {
+  draw(ctx: CanvasRenderingContext2D, width: number, height: number, value: number, rotation: number = 0) {
     const centerX = width / 2;
     const centerY = height / 2;
 
@@ -22,8 +22,8 @@ export class ColorWheelDrawer {
     const degreesPerSector = 360 / this.sectorCount;
 
     for (let sector = 0; sector < this.sectorCount; sector++) {
-      const startAngle = degToRad(sector * degreesPerSector - 90);
-      const endAngle = degToRad((sector + 1) * degreesPerSector - 90);
+      const startAngle = degToRad(sector * degreesPerSector - 90 + rotation);
+      const endAngle = degToRad((sector + 1) * degreesPerSector - 90 + rotation);
       const hue = sector * degreesPerSector;
 
       const gradient = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, this.maxRadius);

--- a/front/src/types/mask.ts
+++ b/front/src/types/mask.ts
@@ -1,5 +1,6 @@
 export interface MaskData {
   value: number;
+  rotation?: number;
   masks: Array<{
     originalPoints: Array<{ x: number; y: number }>;
     scale: number;


### PR DESCRIPTION
回転機能に関連する8ファイル（型定義・描画ロジック・UI・i18nが一体で初めて機能として成立）
- front/src/types/mask.ts — MaskDataにrotation?: number追加
- front/src/lib/colorUtils.ts — getColorFromCoordsにrotation引数を追加し色相計算に反映
- front/src/lib/colorWheelDrawer.ts — drawにrotation引数を追加し描画角度に反映
- front/src/components/MaskMaking.tsx — rotation stateとスライダーUI、保存/復元処理
- front/src/components/PresetCard.tsx / PresetPreview.tsx — プレビュー描画にrotationを反映
- front/messages/en.json / ja.json — rotationラベル追加