### PR TITLE
【修正】スマホ・タブレット環境での処理落ち

### DIFF
--- a/front/src/components/MaskMaking.tsx
+++ b/front/src/components/MaskMaking.tsx
@@ -45,9 +45,18 @@ export function MaskMaking({ onSaveSuccess, copiedMaskData }: MaskMakingProps) {
   // キャンバスを参照
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
-  // 描画インスタンス
-  const colorWheelDrawer = new ColorWheelDrawer;
-  const maskDrawer = new MaskDrawer;
+  // 描画インスタンス（キャッシュを保持するため再レンダーをまたいで永続化する）
+  const colorWheelDrawerRef = useRef<ColorWheelDrawer | null>(null);
+  if (colorWheelDrawerRef.current === null) {
+    colorWheelDrawerRef.current = new ColorWheelDrawer();
+  }
+  const colorWheelDrawer = colorWheelDrawerRef.current;
+
+  const maskDrawerRef = useRef<MaskDrawer | null>(null);
+  if (maskDrawerRef.current === null) {
+    maskDrawerRef.current = new MaskDrawer();
+  }
+  const maskDrawer = maskDrawerRef.current;
 
   // 色相環パラメータ
   const [currentValue, setCurrentValue] = useState<number>(100);

--- a/front/src/lib/MaskDrawer.ts
+++ b/front/src/lib/MaskDrawer.ts
@@ -2,14 +2,26 @@ import { MaskWithScale } from "@/types/gamut";
 import { getScaledPoints } from "./maskUtils";
 
 export class MaskDrawer {
+  // グレーアウト用の一時キャンバス（毎フレーム生成しないよう再利用する）
+  private tempCanvas: HTMLCanvasElement | null = null;
+
   drawMasks(ctx: CanvasRenderingContext2D, selectedMask: MaskWithScale[], canvasWidth: number, canvasHeight: number){
     // グレーアウト用のレイヤーを作成
-    // 一時キャンバスを用意
-    const tempCanvas = document.createElement('canvas');
-    tempCanvas.width = canvasWidth;
-    tempCanvas.height = canvasHeight;
+    if (!this.tempCanvas) {
+      this.tempCanvas = document.createElement('canvas');
+    }
+    const tempCanvas = this.tempCanvas;
+    if (tempCanvas.width !== canvasWidth || tempCanvas.height !== canvasHeight) {
+      tempCanvas.width = canvasWidth;
+      tempCanvas.height = canvasHeight;
+    }
     const tempCtx = tempCanvas.getContext('2d');
     if (!tempCtx) return;
+
+    // 再利用キャンバスのため前フレームの内容をクリア
+    tempCtx.clearRect(0, 0, tempCanvas.width, tempCanvas.height);
+    tempCtx.globalAlpha = 1.0;
+    tempCtx.globalCompositeOperation = "source-over";
 
     // 全体を半透明グレーで塗りつぶす
     tempCtx.globalAlpha = 0.65;

--- a/front/src/lib/colorWheelDrawer.ts
+++ b/front/src/lib/colorWheelDrawer.ts
@@ -5,6 +5,14 @@ export class ColorWheelDrawer {
   private maxRadius: number = 0;  // 初期値を設定
   private sectorCount: number;
 
+  // 無回転状態の色相環を描画したオフスクリーンキャッシュ
+  // グラデーション色は value のみに依存し rotation には依存しないため、
+  // value（とサイズ）が同じ間はこのキャッシュを回転させて描画するだけで済む
+  private cacheCanvas: HTMLCanvasElement | null = null;
+  private cacheValue: number | null = null;
+  private cacheWidth: number = 0;
+  private cacheHeight: number = 0;
+
   constructor(sectorCount: number = 360) {
     this.sectorCount = sectorCount;
   }
@@ -17,16 +25,59 @@ export class ColorWheelDrawer {
     // 最小サイズの75%を半径として使用（余白を確保）
     this.maxRadius = Math.min(width, height) * 0.375;
 
+    if (!this.isCacheValid(width, height, value)) {
+      this.renderToCache(width, height, value);
+    }
+
     ctx.clearRect(0, 0, width, height);
 
+    // キャッシュ済みの無回転色相環を中心点周りに回転させて描画
+    ctx.save();
+    ctx.translate(centerX, centerY);
+    ctx.rotate(degToRad(rotation));
+    ctx.drawImage(this.cacheCanvas!, -centerX, -centerY);
+    ctx.restore();
+
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, this.maxRadius, 0, 2 * Math.PI);
+    ctx.strokeStyle = '#333';
+    ctx.lineWidth = 1;
+    ctx.stroke();
+  }
+
+  private isCacheValid(width: number, height: number, value: number): boolean {
+    return this.cacheCanvas !== null
+      && this.cacheValue === value
+      && this.cacheWidth === width
+      && this.cacheHeight === height;
+  }
+
+  // 無回転状態の色相環をキャッシュキャンバスに描画する
+  private renderToCache(width: number, height: number, value: number) {
+    if (!this.cacheCanvas) {
+      this.cacheCanvas = document.createElement('canvas');
+    }
+
+    if (this.cacheCanvas.width !== width || this.cacheCanvas.height !== height) {
+      this.cacheCanvas.width = width;
+      this.cacheCanvas.height = height;
+    }
+
+    const cacheCtx = this.cacheCanvas.getContext('2d');
+    if (!cacheCtx) return;
+
+    cacheCtx.clearRect(0, 0, width, height);
+
+    const centerX = width / 2;
+    const centerY = height / 2;
     const degreesPerSector = 360 / this.sectorCount;
 
     for (let sector = 0; sector < this.sectorCount; sector++) {
-      const startAngle = degToRad(sector * degreesPerSector - 90 + rotation);
-      const endAngle = degToRad((sector + 1) * degreesPerSector - 90 + rotation);
+      const startAngle = degToRad(sector * degreesPerSector - 90);
+      const endAngle = degToRad((sector + 1) * degreesPerSector - 90);
       const hue = sector * degreesPerSector;
 
-      const gradient = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, this.maxRadius);
+      const gradient = cacheCtx.createRadialGradient(centerX, centerY, 0, centerX, centerY, this.maxRadius);
 
       const gradientSteps = 20;
       for (let i = 0; i <= gradientSteps; i++) {
@@ -36,25 +87,23 @@ export class ColorWheelDrawer {
         gradient.addColorStop(position, `rgb(${r}, ${g}, ${b})`);
       }
 
-      ctx.save();
-      ctx.beginPath();
-      ctx.moveTo(centerX, centerY);
+      cacheCtx.save();
+      cacheCtx.beginPath();
+      cacheCtx.moveTo(centerX, centerY);
 
       const angleBuffer = degToRad(0.1);
-      ctx.arc(centerX, centerY, this.maxRadius, startAngle - angleBuffer, endAngle + angleBuffer);
-      ctx.closePath();
-      ctx.clip();
+      cacheCtx.arc(centerX, centerY, this.maxRadius, startAngle - angleBuffer, endAngle + angleBuffer);
+      cacheCtx.closePath();
+      cacheCtx.clip();
 
-      ctx.fillStyle = gradient;
-      ctx.fillRect(0, 0, width, height);
-      ctx.restore();
+      cacheCtx.fillStyle = gradient;
+      cacheCtx.fillRect(0, 0, width, height);
+      cacheCtx.restore();
     }
 
-    ctx.beginPath();
-    ctx.arc(centerX, centerY, this.maxRadius, 0, 2 * Math.PI);
-    ctx.strokeStyle = '#333';
-    ctx.lineWidth = 1;
-    ctx.stroke();
+    this.cacheValue = value;
+    this.cacheWidth = width;
+    this.cacheHeight = height;
   }
 
   getMaxRadius(){


### PR DESCRIPTION
◼️原因
マスクをドラッグ操作するたびに selectedMask が更新され、それをトリガーに毎フレーム色相環全体（360セクター × 21階調 = 7,560回のHSV→RGB変換 + 360回のクリップ描画）をゼロから再計算していた。PCでは1フレーム内に収まるが、iPadではこの処理が重く、操作への追従が遅れていた。

◼️ 修正内容
1. front/src/lib/colorWheelDrawer.ts 無回転状態の色相環をオフスクリーンキャンバスにキャッシュ。valueとサイズが変わらない限り再計算せず、ctx.translate → rotate → drawImage でキャッシュを回転させて描画するだけに変更。マスクドラッグ中（value/rotation不変）は7,560回の計算が0回になる。

2. front/src/lib/MaskDrawer.ts マスク描画用のオフスクリーンキャンバスを毎回 document.createElement していたのをインスタンス保持・再利用に変更（再利用のためclearRectを追加）。

3. front/src/components/MaskMaking.tsx ColorWheelDrawer/MaskDrawerが毎レンダーで新規生成されキャッシュが保持できなかったため、useRefで永続化。