### PR TITLE
【refactor】メンテナンスモード制御コンポーネントの追加

### DIFF
--- a/.github/workflows/front_ci.yml
+++ b/.github/workflows/front_ci.yml
@@ -25,6 +25,7 @@ jobs:
     env:
       FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
       NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+      NEXT_PUBLIC_MAINTENANCE_MODE: 'true'
 
     steps:
       - name: Checkout code

--- a/front/src/app/[locale]/auth/callback/page.tsx
+++ b/front/src/app/[locale]/auth/callback/page.tsx
@@ -6,8 +6,6 @@ import { useSearchParams } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { Suspense } from 'react';
 import { useLoad } from '@/contexts/LoadingContext';
-import { isMaintenanceMode } from '@/lib/maintenance';
-import { MaintenancePage } from '@/components/MaintenancePage';
 
 function AuthCallbackInner() {
   const router = useRouter();
@@ -62,8 +60,6 @@ function AuthCallbackInner() {
 }
 
 export default function AuthCallback() {
-  if (isMaintenanceMode()) return <MaintenancePage />;
-
   return (
     <Suspense fallback={null}>
       <AuthCallbackInner />

--- a/front/src/app/[locale]/auth/forgot-password/page.tsx
+++ b/front/src/app/[locale]/auth/forgot-password/page.tsx
@@ -16,16 +16,12 @@ import { Label } from "@/components/ui/label";
 import { passwordResets } from '@/lib/api';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useLoad } from '@/contexts/LoadingContext';
-import { isMaintenanceMode } from '@/lib/maintenance';
-import { MaintenancePage } from '@/components/MaintenancePage';
 
 export default function ForgotPassword() {
   const { setIsLoadingOverlay } = useLoad();
   const [errors, setErrors] = useState<string[]>([]);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [email, setEmail] = useState('');
-
-  if (isMaintenanceMode()) return <MaintenancePage />;
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(e.target.value);

--- a/front/src/app/[locale]/auth/layout.tsx
+++ b/front/src/app/[locale]/auth/layout.tsx
@@ -1,0 +1,5 @@
+import { MaintenanceGuard } from '@/components/MaintenanceGuard';
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return <MaintenanceGuard>{children}</MaintenanceGuard>;
+}

--- a/front/src/app/[locale]/auth/login/page.tsx
+++ b/front/src/app/[locale]/auth/login/page.tsx
@@ -19,8 +19,6 @@ import { LoginRequest } from '@/types/auth';
 import { useAuth } from '@/contexts/AuthContext';
 import { useAlert } from '@/contexts/AlertContext';
 import { useLocale, useTranslations } from 'next-intl';
-import { isMaintenanceMode } from '@/lib/maintenance';
-import { MaintenancePage } from '@/components/MaintenancePage';
 
 export default function Login() {
   const router = useRouter();
@@ -33,8 +31,6 @@ export default function Login() {
   });
   const t = useTranslations('Login');
   const locale = useLocale();
-
-  if (isMaintenanceMode()) return <MaintenancePage />;
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;

--- a/front/src/app/[locale]/auth/password-reset/page.tsx
+++ b/front/src/app/[locale]/auth/password-reset/page.tsx
@@ -18,8 +18,6 @@ import { Label } from "@/components/ui/label";
 import { passwordUpdate } from '@/lib/api';
 import { PasswordUpdateRequest } from '@/types/auth';
 import { useLoad } from '@/contexts/LoadingContext';
-import { isMaintenanceMode } from '@/lib/maintenance';
-import { MaintenancePage } from '@/components/MaintenancePage';
 
 function PasswordResetForm() {
   const router = useRouter();
@@ -208,8 +206,6 @@ function PasswordResetForm() {
 }
 
 export default function PasswordReset() {
-  if (isMaintenanceMode()) return <MaintenancePage />;
-
   return (
     <Suspense fallback={null}>
       <PasswordResetForm />

--- a/front/src/app/[locale]/auth/register/page.tsx
+++ b/front/src/app/[locale]/auth/register/page.tsx
@@ -21,8 +21,6 @@ import { LoginRequest } from '@/types/auth';
 import { useAuth } from '@/contexts/AuthContext';
 import { useAlert } from '@/contexts/AlertContext';
 import { useLocale, useTranslations } from 'next-intl';
-import { isMaintenanceMode } from '@/lib/maintenance';
-import { MaintenancePage } from '@/components/MaintenancePage';
 
 export default function Register() {
   const router = useRouter();
@@ -38,8 +36,6 @@ export default function Register() {
   });
   const t = useTranslations('SignUp');
   const locale = useLocale();
-
-  if (isMaintenanceMode()) return <MaintenancePage />;
 
   // フォーム入力値
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/front/src/app/[locale]/comments/[id]/page.tsx
+++ b/front/src/app/[locale]/comments/[id]/page.tsx
@@ -12,8 +12,6 @@ import { UserCircle2Icon } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useAlert } from "@/contexts/AlertContext";
 import { Link } from '@/i18n/routing';
-import { isMaintenanceMode } from '@/lib/maintenance';
-import { MaintenancePage } from '@/components/MaintenancePage';
 
 interface Comment {
   id: number;
@@ -103,8 +101,6 @@ export default function CommentDetailPage() {
       showAlert("コメントの削除に失敗しました");
     }
   };
-
-  if (isMaintenanceMode()) return <MaintenancePage />;
 
   if (isLoading) {
     return (

--- a/front/src/app/[locale]/comments/layout.tsx
+++ b/front/src/app/[locale]/comments/layout.tsx
@@ -1,0 +1,5 @@
+import { MaintenanceGuard } from '@/components/MaintenanceGuard';
+
+export default function CommentsLayout({ children }: { children: React.ReactNode }) {
+  return <MaintenanceGuard>{children}</MaintenanceGuard>;
+}

--- a/front/src/app/[locale]/mypage/layout.tsx
+++ b/front/src/app/[locale]/mypage/layout.tsx
@@ -1,0 +1,5 @@
+import { MaintenanceGuard } from '@/components/MaintenanceGuard';
+
+export default function MyPageSegmentLayout({ children }: { children: React.ReactNode }) {
+  return <MaintenanceGuard>{children}</MaintenanceGuard>;
+}

--- a/front/src/app/[locale]/mypage/profiles/page.tsx
+++ b/front/src/app/[locale]/mypage/profiles/page.tsx
@@ -53,7 +53,7 @@ export default function ProfilesPage() {
   const { setIsLoadingOverlay } = useLoad();
   const { updateUser } = useAuth();
   const { showAlert } = useAlert();
-  const { isAuthenticated, maintenance } = useAuthRedirect();
+  const { isAuthenticated } = useAuthRedirect();
   const [profileUser, setProfileUser] = useState<UserType | null>(null);
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
   const [avatarFile, setAvatarFile] = useState<File | null>(null);

--- a/front/src/app/[locale]/settings/delete-account/page.tsx
+++ b/front/src/app/[locale]/settings/delete-account/page.tsx
@@ -11,16 +11,13 @@ import { useAuthRedirect } from "@/hooks/useAuthRedirect";
 import { BackButton } from '@/components/BackButton';
 import { signOut } from '@/lib/api';
 import { useLoad } from '@/contexts/LoadingContext';
-import { MaintenancePage } from '@/components/MaintenancePage';
 
 export default function DeleteAccountPage() {
-  const { maintenance } = useAuthRedirect();
+  useAuthRedirect();
   const router = useRouter();
   const { setIsLoadingOverlay } = useLoad();
   const [errors, setErrors] = useState<string[]>([]);
   const [agreedToDelete, setAgreedToDelete] = useState(false);
-
-  if (maintenance) return <MaintenancePage />;
 
   const validateForm = (): boolean => {
     const newErrors: string[] = [];

--- a/front/src/app/[locale]/settings/email/page.tsx
+++ b/front/src/app/[locale]/settings/email/page.tsx
@@ -15,10 +15,9 @@ import { useAuthRedirect } from "@/hooks/useAuthRedirect";
 import { changeEmail } from '@/lib/api';
 import { useLoad } from '@/contexts/LoadingContext';
 import { useTranslations } from 'next-intl';
-import { MaintenancePage } from '@/components/MaintenancePage';
 
 export default function EmailChangePage() {
-  const { maintenance } = useAuthRedirect();
+  useAuthRedirect();
   const router = useRouter();
   const { setIsLoadingOverlay } = useLoad();
   const { user, updateUser } = useAuth();
@@ -29,8 +28,6 @@ export default function EmailChangePage() {
     newEmail: '',
     password: ''
   });
-
-  if (maintenance) return <MaintenancePage />;
 
   // SNS認証ユーザーは非表示
   if (user?.has_social_accounts) {

--- a/front/src/app/[locale]/settings/layout.tsx
+++ b/front/src/app/[locale]/settings/layout.tsx
@@ -1,0 +1,5 @@
+import { MaintenanceGuard } from '@/components/MaintenanceGuard';
+
+export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+  return <MaintenanceGuard>{children}</MaintenanceGuard>;
+}

--- a/front/src/app/[locale]/settings/page.tsx
+++ b/front/src/app/[locale]/settings/page.tsx
@@ -7,14 +7,11 @@ import { MdArrowForwardIos } from "react-icons/md";
 import { useAuthRedirect } from "@/hooks/useAuthRedirect";
 import { useAuth } from '@/contexts/AuthContext';
 import { useTranslations } from 'next-intl';
-import { MaintenancePage } from '@/components/MaintenancePage';
 
 export default function SettingsPage() {
-  const { isLoading, maintenance } = useAuthRedirect();
+  const { isLoading } = useAuthRedirect();
   const { user } = useAuth();
   const t = useTranslations('Settings');
-
-  if (maintenance) return <MaintenancePage />;
 
   // 認証状態の初期化中、またはユーザー情報がない場合は何も表示しない
   if (isLoading || !user) {

--- a/front/src/app/[locale]/users/[id]/page.tsx
+++ b/front/src/app/[locale]/users/[id]/page.tsx
@@ -8,8 +8,6 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { UserCircle2Icon } from "lucide-react";
 import XLogo from "@/components/XLogo";
 import { useLoad } from "@/contexts/LoadingContext";
-import { isMaintenanceMode } from "@/lib/maintenance";
-import { MaintenancePage } from "@/components/MaintenancePage";
 
 export default function UserProfilePage() {
   const params = useParams();
@@ -42,8 +40,6 @@ export default function UserProfilePage() {
       fetchUser();
     }
   }, [userId]);
-
-  if (isMaintenanceMode()) return <MaintenancePage />;
 
   if (error || !user) {
     return (

--- a/front/src/app/[locale]/users/layout.tsx
+++ b/front/src/app/[locale]/users/layout.tsx
@@ -1,0 +1,5 @@
+import { MaintenanceGuard } from '@/components/MaintenanceGuard';
+
+export default function UsersLayout({ children }: { children: React.ReactNode }) {
+  return <MaintenanceGuard>{children}</MaintenanceGuard>;
+}

--- a/front/src/app/[locale]/work/[id]/edit/page.tsx
+++ b/front/src/app/[locale]/work/[id]/edit/page.tsx
@@ -29,7 +29,6 @@ import { PresetSelectDialog } from "@/components/PresetSelectDialog";
 import { updateWork, showWork, getWorkImageBlob } from "@/lib/api";
 import { useAuthRedirect } from "@/hooks/useAuthRedirect";
 import { useLoad } from "@/contexts/LoadingContext";
-import { MaintenancePage } from "@/components/MaintenancePage";
 
 // 型定義(公開設定)
 type PublicStatus = 0 | 1 | 2; // published: 0, restricted: 1, draft: 2
@@ -55,7 +54,7 @@ export default function EditWorks() {
   const { setIsLoadingOverlay } = useLoad();
   const params = useParams();
   const { user } = useAuth();
-  const { isAuthenticated, isLoading, maintenance } = useAuthRedirect();
+  const { isAuthenticated, isLoading } = useAuthRedirect();
   const id = params?.id;
   const currentObjectUrl = useRef<string | null>(null); // ObjectURLの管理用ref
   const [showUnauthorizedDialog, setShowUnauthorizedDialog] = useState(false);
@@ -290,9 +289,6 @@ export default function EditWorks() {
       setIsLoadingOverlay(false);
     }
   };
-
-  // メンテナンスモード中はメンテナンスページを表示
-  if (maintenance) return <MaintenancePage />;
 
   // 認証状態の初期化中、またはユーザー情報がない場合は何も表示しない
   if (isLoading || !user) {

--- a/front/src/app/[locale]/work/[id]/page.tsx
+++ b/front/src/app/[locale]/work/[id]/page.tsx
@@ -63,7 +63,8 @@ export async function generateMetadata(
 }
 
 export default async function Page({ params }: Props) {
-  // メンテナンスモード中はホームにリダイレクト
+  // メンテナンスモード中は work/layout.tsx の MaintenanceGuard によりこのページ自体が
+  // 描画されないため、通常この分岐には到達しない（ガードが外れた場合の防御として残置）
   if (isMaintenanceMode()) {
     redirect('/');
   }

--- a/front/src/app/[locale]/work/layout.tsx
+++ b/front/src/app/[locale]/work/layout.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import { generateAlternates } from '@/lib/metadata';
+import { MaintenanceGuard } from '@/components/MaintenanceGuard';
 
 interface Props {
   params: Promise<{ locale: string }>;
@@ -18,5 +19,5 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 export default function WorkLayout({ children }: { children: React.ReactNode;}) {
-  return <>{children}</>;
+  return <MaintenanceGuard>{children}</MaintenanceGuard>;
 }

--- a/front/src/app/[locale]/work/new/page.tsx
+++ b/front/src/app/[locale]/work/new/page.tsx
@@ -20,7 +20,6 @@ import { useAuthRedirect } from "@/hooks/useAuthRedirect";
 import { useLoad } from "@/contexts/LoadingContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { useTranslations } from "next-intl";
-import { MaintenancePage } from "@/components/MaintenancePage";
 
 // 型定義(公開設定)
 type PublicStatus = 0 | 1 | 2; // published: 0, restricted: 1, draft: 2
@@ -30,7 +29,7 @@ export default function PostWorks() {
   const { setIsLoadingOverlay } = useLoad();
   const { showAlert } = useAlert();
   const { user } = useAuth();
-  const { isAuthenticated, isLoading, maintenance } = useAuthRedirect();
+  const { isAuthenticated, isLoading } = useAuthRedirect();
   const [errors, setErrors] = useState<string[]>([]);
   const [formData, setFormData] = useState({
     title: '',
@@ -121,9 +120,6 @@ export default function PostWorks() {
       setIsLoadingOverlay(false);
     }
   };
-
-  // メンテナンスモード中はメンテナンスページを表示
-  if (maintenance) return <MaintenancePage />;
 
   // 認証状態の初期化中、またはユーザー情報がない場合は何も表示しない
   if (isLoading || !user ) {

--- a/front/src/app/[locale]/work/page.tsx
+++ b/front/src/app/[locale]/work/page.tsx
@@ -17,8 +17,6 @@ import { Badge } from "@/components/ui/badge";
 import { UserCircle2Icon } from "lucide-react";
 import { useLoad } from "@/contexts/LoadingContext";
 import { useLocale, useTranslations } from "next-intl";
-import { isMaintenanceMode } from "@/lib/maintenance";
-import { MaintenancePage } from "@/components/MaintenancePage";
 
 function WorksListContent() {
   const { user } = useAuth();
@@ -307,8 +305,6 @@ function WorksListContent() {
 }
 
 export default function WorksList() {
-  if (isMaintenanceMode()) return <MaintenancePage />;
-
   return (
     <Suspense fallback={null}>
       <WorksListContent />

--- a/front/src/components/MaintenanceGuard.tsx
+++ b/front/src/components/MaintenanceGuard.tsx
@@ -1,0 +1,14 @@
+import { isMaintenanceMode } from '@/lib/maintenance';
+import { MaintenancePage } from '@/components/MaintenancePage';
+
+/**
+ * メンテナンスモード中は配下のページを MaintenancePage に差し替えるガード。
+ * API依存セグメントの layout.tsx で children を包んで使う。
+ * メンテ中は配下のページ（クライアント・サーバーとも）は描画されない（E2Eで確認済み）。
+ * ただし generateMetadata はガードの外で実行されるため、API呼び出しを伴う場合は
+ * work/[id]/page.tsx のように generateMetadata 側に個別ガードが必要。
+ */
+export function MaintenanceGuard({ children }: { children: React.ReactNode }) {
+  if (isMaintenanceMode()) return <MaintenancePage />;
+  return <>{children}</>;
+}

--- a/front/src/components/MyPageLayout.tsx
+++ b/front/src/components/MyPageLayout.tsx
@@ -7,7 +7,6 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { UserCircle2Icon } from "lucide-react";
 import XLogo from "./XLogo";
 import { useAuthRedirect } from "@/hooks/useAuthRedirect";
-import { MaintenancePage } from "@/components/MaintenancePage";
 import { motion } from "motion/react";
 
 const tabs = [
@@ -22,12 +21,10 @@ interface MyPageLayoutProps {
 }
 
 export function MyPageLayout({ children }: MyPageLayoutProps) {
-  const { isLoading, maintenance } = useAuthRedirect();
+  const { isLoading } = useAuthRedirect();
   const pathname = usePathname();
   const router = useRouter();
   const { user } = useAuth();
-
-  if (maintenance) return <MaintenancePage />;
 
   // 認証状態の初期化中は何も表示しない（LoadingOverlayが表示）
   if (isLoading || !user) {

--- a/front/src/hooks/useAuthRedirect.ts
+++ b/front/src/hooks/useAuthRedirect.ts
@@ -43,5 +43,5 @@ export const useAuthRedirect = () => {
   }, [isAuthenticated, isLoading, router, setIsLoadingOverlay, maintenance]);
 
   // メンテナンスモード中は常に未認証として返す
-  return { isAuthenticated: maintenance ? false : isAuthenticated, isLoading: maintenance ? false : isLoading, maintenance };
+  return { isAuthenticated: maintenance ? false : isAuthenticated, isLoading: maintenance ? false : isLoading };
 };

--- a/front/tests/maintenance-guard.spec.ts
+++ b/front/tests/maintenance-guard.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * メンテナンスモードガードのテスト
+ * front/.env の NEXT_PUBLIC_MAINTENANCE_MODE=true（常時メンテモード）前提。
+ * API依存セグメント（auth / users / comments / settings / mypage / work）は
+ * 各セグメントの layout.tsx の MaintenanceGuard により MaintenancePage が表示される。
+ * 見出し文言: messages/en.json の Maintenance.page_unavailable_title
+ */
+const guardedRoutes = [
+  '/en/work',
+  '/en/work/new',
+  // work/[id] はサーバーページだが、レイアウトガードにより描画されず
+  // ページ内の redirect('/') も発火しない（他ルートと同じ MaintenancePage 表示になる）
+  '/en/work/1',
+  '/en/auth/login',
+  '/en/auth/register',
+  '/en/settings',
+  '/en/settings/password',
+  '/en/mypage',
+  '/en/users/1',
+  '/en/comments/1',
+];
+
+test.describe('メンテナンスモードガード', () => {
+  for (const route of guardedRoutes) {
+    test(`${route} はメンテナンスページを表示する`, async ({ page }) => {
+      await page.goto(route);
+      await expect(
+        page.getByRole('heading', { name: 'Feature Temporarily Unavailable' })
+      ).toBeVisible();
+    });
+  }
+
+  test('/en/mask はメンテナンス中も利用できる', async ({ page }) => {
+    await page.goto('/en/mask');
+    await expect(
+      page.getByRole('heading', { name: 'Feature Temporarily Unavailable' })
+    ).toHaveCount(0);
+    await expect(page.locator('canvas').first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
・新規コンポーネント MaintenanceGuard を作成
=> メンテナンス時に非表示させたいページの layout.tsx で {children} を当該コンポーネントでラップすることにより、page.tsx を編集することなく表示制御を可能とした。