### PR TITLE
【fix】maskページのCore Web Vitals改善

### DIFF
--- a/front/next.config.ts
+++ b/front/next.config.ts
@@ -9,8 +9,9 @@ const withPWA = withPWAInit({
   workboxOptions: {
     skipWaiting: true,
     exclude: [
-      // 以下のファイルは存在しないため、ビルド時にキャッシュ対象として認識しないように除外
-      /\/_next\/dynamic-css-manifest\.json$/
+      // 本番で配信されない（404になる）ため、precache対象から除外
+      // ※excludeは「/_next/」プレフィックスが付く前のアセット名に対して評価されるため、末尾一致で書く
+      /dynamic-css-manifest\.json$/
     ]
   }
 });

--- a/front/src/app/[locale]/layout.tsx
+++ b/front/src/app/[locale]/layout.tsx
@@ -2,12 +2,18 @@ import type { Metadata } from 'next'
 import '@/app/globals.css'
 import { ClientLayout } from './client-layout'
 import { generateJsonLd } from '@/lib/structured-data'
-import { getMessages, getTranslations } from 'next-intl/server'
+import { getMessages, getTranslations, setRequestLocale } from 'next-intl/server'
 import { NextIntlClientProvider } from 'next-intl'
+import { routing } from '@/i18n/routing'
 
 interface Props {
   children: React.ReactNode;
   params: Promise<{ locale: string }>
+}
+
+// 対応言語（en / ja）のページをビルド時に事前生成し、表示開始（LCP）を速くする
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -80,6 +86,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function RootLayout({ children, params }: Props) {
   // paramsから 'ja' or 'en' を取得
   const { locale } = await params;
+
+  // next-intlに言語を直接伝えて静的生成を成立させる（無いと動的レンダリングに戻る）
+  setRequestLocale(locale);
 
   // 言語ファイルを読み込み
   const messages = await getMessages();

--- a/front/src/components/Header.tsx
+++ b/front/src/components/Header.tsx
@@ -122,9 +122,12 @@ export function Header() {
               <Image
                 src='/app_logo.svg'
                 alt="GamutCut"
-                width={100}
+                // 縦横比はSVG本来の比率（約5.15:1）に合わせる（ずれるとCLS・警告の原因）
+                width={103}
                 height={20}
-                sizes="100px"
+                sizes="103px"
+                className="h-5 w-auto"
+                priority  // LCP対象のロゴのため優先読み込み
               />
             </Link>
           </div>

--- a/front/src/components/MaskMaking.tsx
+++ b/front/src/components/MaskMaking.tsx
@@ -460,9 +460,30 @@ export function MaskMaking({ onSaveSuccess, copiedMaskData }: MaskMakingProps) {
     }
   }, [copiedMaskData]);
 
+  // 初回の描画が終わったかどうか
+  const hasDrawnRef = useRef(false);
+
   // 再描画トリガー
+  // 初回のみ、ページ表示を優先するため描画をrAF2回分あとに遅らせる（詳細: docs/maskMaking.md）
   useEffect(() => {
-    redraw();
+    if (hasDrawnRef.current) {
+      redraw();
+      return;
+    }
+
+    let cancelled = false;
+    const rafId = requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (cancelled) return;
+        hasDrawnRef.current = true;
+        redraw();
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(rafId);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentValue, rotation, selectedMask]);
 

--- a/front/src/lib/colorWheelDrawer.ts
+++ b/front/src/lib/colorWheelDrawer.ts
@@ -9,8 +9,6 @@ export class ColorWheelDrawer {
   private cacheCanvas: HTMLCanvasElement | null = null;
   private cacheWidth: number = 0;
   private cacheHeight: number = 0;
-  // cacheCanvasから取得した明度100%基準のピクセルデータ
-  private cachePixelData: ImageData | null = null;
 
   // 現在の明度(value)を適用した結果を保持するオフスクリーンキャンバス
   private valueCanvas: HTMLCanvasElement | null = null;
@@ -95,25 +93,20 @@ export class ColorWheelDrawer {
         gradient.addColorStop(position, `rgb(${r}, ${g}, ${b})`);
       }
 
-      cacheCtx.save();
+      // 扇形の内側だけを直接塗る（全面塗り＋切り抜きより大幅に軽い。詳細: docs/colorWheelDrawer.md）
       cacheCtx.beginPath();
       cacheCtx.moveTo(centerX, centerY);
 
       const angleBuffer = degToRad(0.1);
       cacheCtx.arc(centerX, centerY, this.maxRadius, startAngle - angleBuffer, endAngle + angleBuffer);
       cacheCtx.closePath();
-      cacheCtx.clip();
 
       cacheCtx.fillStyle = gradient;
-      cacheCtx.fillRect(0, 0, width, height);
-      cacheCtx.restore();
+      cacheCtx.fill();
     }
 
     this.cacheWidth = width;
     this.cacheHeight = height;
-
-    // 明度100%基準のピクセルデータを保持しておく
-    this.cachePixelData = cacheCtx.getImageData(0, 0, width, height);
 
     // valueCanvasもcacheCanvasと同サイズに揃え、明度の再計算を強制する
     if (!this.valueCanvas) {
@@ -126,25 +119,30 @@ export class ColorWheelDrawer {
     this.lastValue = null;
   }
 
-  // cachePixelDataに明度(value/100)を乗算してvalueCanvasに反映する
+  // 色相環に明度を反映してvalueCanvasに描き出す。
+  // JSのピクセルループではなくCanvasの合成モードで一括適用する（詳細: docs/colorWheelDrawer.md）
   private applyBrightness(value: number, width: number, height: number) {
-    if (!this.cachePixelData || !this.valueCanvas) return;
+    if (!this.cacheCanvas || !this.valueCanvas) return;
 
     const valueCtx = this.valueCanvas.getContext('2d');
     if (!valueCtx) return;
 
-    const factor = value / 100;
-    const src = this.cachePixelData.data;
-    const dst = new Uint8ClampedArray(src.length);
+    valueCtx.clearRect(0, 0, width, height);
+    valueCtx.drawImage(this.cacheCanvas, 0, 0);
 
-    for (let i = 0; i < src.length; i += 4) {
-      dst[i] = src[i] * factor;
-      dst[i + 1] = src[i + 1] * factor;
-      dst[i + 2] = src[i + 2] * factor;
-      dst[i + 3] = src[i + 3];
-    }
+    // 明度100%はキャッシュそのままで終了
+    if (value >= 100) return;
 
-    valueCtx.putImageData(new ImageData(dst, width, height), 0, 0);
+    const v = Math.round(255 * value / 100);
+    valueCtx.save();
+    // 乗算合成でグレーを重ね、全体を明度の割合だけ暗くする
+    valueCtx.globalCompositeOperation = 'multiply';
+    valueCtx.fillStyle = `rgb(${v}, ${v}, ${v})`;
+    valueCtx.fillRect(0, 0, width, height);
+    // 円の外側まで塗られたグレーを、元の色相環の円形に切り抜き直す
+    valueCtx.globalCompositeOperation = 'destination-in';
+    valueCtx.drawImage(this.cacheCanvas, 0, 0);
+    valueCtx.restore();
   }
 
   getMaxRadius(){


### PR DESCRIPTION
1. ヘッダーロゴの修正（front/src/components/Header.tsx）
=> priority` を追加して優先読み込みにする。寸法指定を SVG 本来の縦横比に合わせて `width={103} height={20}` に修正。

2. 色相環の最初の描画を軽くする（front/src/lib/colorWheelDrawer.ts, front/src/components/MaskMaking.tsx）
=> 扇形1枚ごとに「全面を塗って切り抜く」のをやめ、扇形の形だけを直接塗るように変更。見た目は同じまま、塗る面積が大幅に減る。

3. 明度処理をブラウザの合成機能に任せる（front/src/lib/colorWheelDrawer.ts）
明度の変更処理を JS のループではなく、canvas の描画モード（乗算）に変更。
明度100%のときは処理自体をスキップ。

4. ページの静的生成（front/src/app/[locale]/layout.tsx）
ビルド時に各言語のHTMLページ（`/en/mask` `/ja/mask`）を生成するようにした。

